### PR TITLE
Add support for HCCS A3000 IDE card

### DIFF
--- a/ecide.h
+++ b/ecide.h
@@ -115,13 +115,15 @@ typedef struct {
 
 typedef enum {
         HOST_ZIDEFS,
-        HOST_CASTLE
+        HOST_CASTLE,
+        HOST_HCCS
 } host_type_t;
 
 typedef struct {
         int                     slot;
         regs_t                  regs;
-        regs_t                  hi_latch;   /* If zero, 16b access is supported */
+        regs_t                  hi_latch_write;   /* If zero, 16b access is supported */
+        regs_t                  hi_latch_read;    /* these two latches may be the same */
         host_type_t             type;
         drive_info_t            drives[2];
         int                     card_num;

--- a/rix_kern_build.patch
+++ b/rix_kern_build.patch
@@ -28,16 +28,18 @@
 >         /* FIXME: ecide as char dev! */
 *** conf/xcbconf.c-orig
 --- conf/xcbconf.c
-126a127,134
+126a127,136
 > #if NIDE > 0
-> extern void ecide_init_zidefs(), ecide_init_castle();
+> extern void ecide_init_zidefs(), ecide_init_castle(), ecide_init_hccs();
 > extern void ecide_init_low(), ecide_shutdown();
 > extern struct scavenge ecide_scavenge;
 > #define XCB_COMPANY_CASTLE      85
 > #define XCB_PRODUCT_IDE_EURO16  231
+> #define XCB_COMPANY_HCCS        0x000c
+> #define XCB_PRODUCT_HCCS_IDE_A3000 0x0022
 > #endif
 > 
-163a172,180
+163a174,184
 > #endif
 > #if NIDE > 0
 >   /* ICS/IanS IDE podule with ZIDEFS rom */
@@ -46,6 +48,8 @@
 >   /* Note the original ICS podule ROM uses XCB_COMPANY_IANCOPESTAKESOFTWARE & XCB_COUNTRY_UK */
 >   { { XCB_PRODUCT_IDE_EURO16, XCB_COMPANY_CASTLE, XCB_COUNTRY_UK },
 >     0, ecide_init_castle, ecide_init_low, ecide_shutdown, 0 /* &ecide_scavenge */ },
+>   { { XCB_PRODUCT_HCCS_IDE_A3000, XCB_COMPANY_HCCS, XCB_COUNTRY_UK},
+>     0, ecide_init_hccs, ecide_init_low, ecide_shutdown, 0},
 >   /* Can't scavenge unless every podule sharing that code doesn't probe! */
 *** M/Makefile-orig
 --- M/Makefile


### PR DESCRIPTION
Decided that I wanted to experience ancient Unix on my A3000, so I hacked in support for the HCCS IDE card that I have in it. Had to make a few modifications in support of this - allowing for the high-byte register to be in different locations for reads and writes, and returning the address of the following sector when probing for an ADFS volume. These shouldn't have any impact on the function of other cards, but I'm not really able to test that.

The Armstrong Walker IDEFS used by the HCCS card has a very simplistic 'partitioning' scheme - it simply has up to 4 ADFS volumes concatenated together, with no partition table. I haven't completely worked out a partitioning tool to create RISCiX partitions in this scheme, but an afternoon with a calculator and a hex editor got me a valid partition table that seems to keep both IDEFS and RISCiX happy.